### PR TITLE
[Ready for review] Iss30/create docker container for local development

### DIFF
--- a/client/.dockerignore
+++ b/client/.dockerignore
@@ -1,0 +1,2 @@
+node_modules
+npm-debug.log

--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -1,0 +1,20 @@
+# Create image based on the official Node image from dockerhub
+FROM node:18
+
+# Set the working directory inside the container
+WORKDIR /app/client
+
+# Copy package.json
+COPY package.json .
+
+# Install dependencies
+RUN npm install --legacy-peer-deps
+
+# Copy the rest of the front end code
+COPY . .
+
+# Expose port 3001
+EXPOSE 3001
+
+# Serve the app
+CMD ["npm", "start"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,21 @@
+version: '3.8'
+services:
+  server:
+    build:
+      context: ./server
+      dockerfile: Dockerfile
+    ports:
+      - "3000:3000"
+    volumes:
+      - ./server:/app/server
+    env_file:
+      - ./server/.env
+
+  client:
+    build:
+      context: ./client
+      dockerfile: Dockerfile
+    ports:
+      - "3001:3000"
+    volumes:
+      - ./client:/app/client

--- a/server/.dockerignore
+++ b/server/.dockerignore
@@ -1,0 +1,2 @@
+node_modules
+npm-debug.log

--- a/server/.env.example
+++ b/server/.env.example
@@ -1,6 +1,16 @@
+# For local development on MacOS
 DB_USER=climate_geo_data_user
 DB_PASS=climate_password
 DB_HOST=localhost:5432
 DB_DATABASE=climate_geo_data
 ADMIN_LOGIN=admin
 ADMIN_PASS=climate_password
+
+# For Docker and MacOS
+# DB_USER=climate_geo_data_user
+# DB_PASS=climate_password
+# DB_PORT=5432
+# DB_HOST=docker.for.mac.host.internal
+# DB_DATABASE=climate_geo_data
+# ADMIN_LOGIN=admin
+# ADMIN_PASS=climate_password

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,0 +1,20 @@
+# Create image based on the official Node image from dockerhub
+FROM node:18
+
+# Set the working directory inside the container
+WORKDIR /app/server
+
+# Copy package.json
+COPY package.json .
+
+# Install dependencies
+RUN npm install
+
+# Copy the rest of the back end code
+COPY . .
+
+# Expose port 3000
+EXPOSE 3000
+
+# Start the Node.js server
+CMD ["npm", "start"]


### PR DESCRIPTION
Closes https://github.com/UniExeterRSE/LCAT-issues/issues/30

This PR:
* Adds Dockerfiles for client and server local development on MacOS
* Creates a `docker-compose.yml`, that can utilise .env variables, to access a Postgres db outside the container

To run, on MacOS:
* Ensure the correct .env variables are set (i.e. `DB_PORT` and `DB_HOST`)
* With Postgres server running, run the usual `docker-compose up` and visit `localhost:3001` to view client
